### PR TITLE
Fix: api_token doesn't work

### DIFF
--- a/selectel_dns.py
+++ b/selectel_dns.py
@@ -174,11 +174,12 @@ def main():
     state = module.params.get('state')
     is_solo = module.params.get('solo')
 
-    if not api_token and os.environ.get('SELECTEL_API_KEY'):
+    if not api_token:
+        if not os.environ.get('SELECTEL_API_KEY'):
+            module.fail_json(
+                msg="You must define api_token or env SELECTEL_API_KEY")
+
         api_token = os.environ.get('SELECTEL_API_KEY')
-    else:
-        module.fail_json(
-            msg="You must define api_token or env SELECTEL_API_KEY")
 
     config = selectel_dns_api.rest.Configuration()
     config.api_key = {'X-Token': api_token}


### PR DESCRIPTION
Hi, @popstas! The `api_token` parameter doesn't work as expected due to an incorrect `if` statement.