### PR TITLE
Fix Python 3 incompatibility

### DIFF
--- a/selectel_dns.py
+++ b/selectel_dns.py
@@ -125,6 +125,7 @@ EXAMPLES = '''
 
 import os
 import re
+import sys
 from ansible.module_utils.basic import AnsibleModule
 try:
     import selectel_dns_api
@@ -135,10 +136,10 @@ except ImportError:
 
 
 def domain_idna(domain):
-    if isinstance(domain, str):
+    if sys.version_info.major == 2:
         return domain.decode('utf-8').encode('idna')
-    else:
-        return domain.encode('idna')
+
+    return str(domain.encode('idna'), 'utf-8')
 
 
 def main():


### PR DESCRIPTION
In Python 3 method `str.encode` returns a result having type `bytes`, not a `str`. See:

- https://docs.python.org/3/library/stdtypes.html#str.encode
- https://docs.python.org/2/library/stdtypes.html#str.encode
- https://portingguide.readthedocs.io/en/latest/strings.html#strings